### PR TITLE
Package startup message

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -1,5 +1,5 @@
-.onAttach <- function(libname, pkgname) {
-  packageStartupMessage("Use authorize() function to begin give the package the proper credentials to run. ")
+.onLoad <- function(libname, pkgname) {
+  packageStartupMessage("To begin, run authorize() to supply rgoogleclassroom the proper credentials to run.")
 }
 
 .classroomEnv <- new.env(parent = emptyenv())


### PR DESCRIPTION
I replaced `.onAttach()` with `.onLoad()`.  `.onLoad()` runs when the package is loaded. If something has to happen before anything is run, that's the way to go. `.onAttach()` only runs when the library is attached, e.g. when somebody calls `library(your_package)`. `.onLoad()` will also run when somebody loads but doesn't attach your package by calling `pkg::fun`.

Sources: 
- https://community.rstudio.com/t/when-to-use-onload-vs-onattach/21953
- https://r-pkgs.org/dependencies-mindset-background.html#sec-dependencies-attach-vs-load
- https://r-pkgs.org/code.html#sec-code-onLoad-onAttach

